### PR TITLE
typo fix for manage users permission

### DIFF
--- a/src/modules/core/authorization/authorization.constants.js
+++ b/src/modules/core/authorization/authorization.constants.js
@@ -1,6 +1,6 @@
 const Services = {
     PLATFORM: "platform-management",
-    MANAGE_USER: "manage-user",
+    MANAGE_USER: "manage-users",
     MANAGE_PROFILE: "manage-profiles",
     MANAGE_SHOP: "manage-shop",
     MANAGE_CLIENT: "manage-client",


### PR DESCRIPTION
Probably A typo fixed for update guard permissions API
Way to reproduce the bug:
```
POST /api/login
GET /api/users/1
Response:
Forbidden. You are not authorized.
```
See also:
[Matching permissions](https://github.com/UitsHabib/shop-on/blob/main/src/modules/core/authorization/authorization.middlewares.js#L55)